### PR TITLE
chore: remove coronavirus test graphs

### DIFF
--- a/src/pages/Coronavirus.vue
+++ b/src/pages/Coronavirus.vue
@@ -22,12 +22,10 @@
         :daily="$page.byProvince.edges[0].node.list"
         :provinces="provinces"
       />
-      <CoronavirusTrendTests />
       <CoronavirusMap
         :daily="$page.byProvince.edges[0].node.list"
         :provinces="provinces"
       />
-      <CoronavirusTrendAffectedCities />
       <CoronavirusTrend :daily="$page.allCoronavirus.edges[0].node.daily" />
     </main>
   </Layout>
@@ -37,10 +35,8 @@
 import CoronavirusMap from '~/components/CoronavirusMap.vue'
 import CoronavirusSummary from '~/components/CoronavirusSummary.vue'
 import CoronavirusTrend from '~/components/CoronavirusTrend.vue'
-import CoronavirusTrendAffectedCities from '~/components/CoronavirusTrendAffectedCities.vue'
 import CoronavirusTrendByProvince from '~/components/CoronavirusTrendByProvince.vue'
 import CoronavirusTrendNewCases from '~/components/CoronavirusTrendNewCases.vue'
-import CoronavirusTrendTests from '~/components/CoronavirusTrendTests.vue'
 
 export default {
   metaInfo() {
@@ -50,10 +46,8 @@ export default {
     CoronavirusMap,
     CoronavirusSummary,
     CoronavirusTrend,
-    CoronavirusTrendAffectedCities,
     CoronavirusTrendByProvince,
-    CoronavirusTrendNewCases,
-    CoronavirusTrendTests
+    CoronavirusTrendNewCases
   },
   computed: {
     meta() {

--- a/src/pages/DasborCovid19.vue
+++ b/src/pages/DasborCovid19.vue
@@ -36,8 +36,6 @@
         :provinces="provinces"
         locale="id"
       />
-      <CoronavirusTrendAffectedCities locale="id" />
-      <CoronavirusTrendTests locale="id" />
     </main>
   </Layout>
 </template>
@@ -45,11 +43,9 @@
 <script>
 import CoronavirusMap from '~/components/CoronavirusMap.vue'
 import CoronavirusSummary from '~/components/CoronavirusSummary.vue'
-import CoronavirusTrendAffectedCities from '~/components/CoronavirusTrendAffectedCities.vue'
 import CoronavirusTrendByProvince from '~/components/CoronavirusTrendByProvince.vue'
 import CoronavirusTrendNewCases from '~/components/CoronavirusTrendNewCases.vue'
 import CoronavirusTrendTable from '~/components/CoronavirusTrendTable.vue'
-import CoronavirusTrendTests from '~/components/CoronavirusTrendTests.vue'
 import Layout from '~/layouts/Id.vue'
 
 export default {
@@ -59,11 +55,9 @@ export default {
   components: {
     CoronavirusMap,
     CoronavirusSummary,
-    CoronavirusTrendAffectedCities,
     CoronavirusTrendByProvince,
     CoronavirusTrendNewCases,
     CoronavirusTrendTable,
-    CoronavirusTrendTests,
     Layout,
   },
   computed: {


### PR DESCRIPTION
Remove coronavirus trend test and affected cities because it is no longer relevant and need a manual update the data daily.